### PR TITLE
build_local_zipnum ignores shard number using latest mrjob

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mrjob
+mrjob==0.5.11
 boto
 pywb
 #-e git+https://github.com/matteobertozzi/Hadoop.git#egg=hadoop&subdirectory=python-hadoop


### PR DESCRIPTION
Changes in the newest version of mrjob result in build_local_zipnum ignoring shard number and a load of deprecated warnings showing. Specifying mrjob==0.5.11 restores functionality.